### PR TITLE
fix(middleware): add request when scope type is http

### DIFF
--- a/fastapi_structlog/middleware/structlog.py
+++ b/fastapi_structlog/middleware/structlog.py
@@ -42,13 +42,14 @@ class StructlogMiddleware:
         if request_id := correlation_id.get():
             structlog.contextvars.bind_contextvars(request_id=request_id)
 
-        request = {
-            'method': scope.get('method'),
-            'path': get_path_with_query_string(scope),
-            'client_addr': get_client_addr(scope),
-            'user_agent': get_user_agent(scope),
-        }
-        structlog.contextvars.bind_contextvars(request=request)
+        if scope.get('type', '').startswith('http'):
+            request = {
+                'method': scope.get('method'),
+                'path': get_path_with_query_string(scope),
+                'client_addr': get_client_addr(scope),
+                'user_agent': get_user_agent(scope),
+            }
+            structlog.contextvars.bind_contextvars(request=request)
 
         try:
             await self.app(scope, receive, send)


### PR DESCRIPTION
Если в настройке приложения используется lifespan, то появляется scope вот такого вида:
`{'type': 'lifespan', 'asgi': {'version': '3.0', 'spec_version': '2.0'}, 'state': {}, 'app': <fastapi.applications.FastAPI object at 0x7fe2ed2ac350>}
и ему request явно не стоит добавлять. Так же вероятно могут появляться scope и других типов кроме http.`