### PR TITLE
feat(sentry): failed_request_status_codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ in the `app_slug@version` format.
 Another Sentry configuration option is to use
 `fastapi_structlog.sentry.setup_sentry`. However, in this case,
 you must explicitly pass an instance of the settings
-`fastapi_structlog.sentry.SentrySettings` and the `release` parameter.
+`fastapi_structlog.sentry.SentrySettings` and the `release` parameter. In addition,
+you can pass the `failed_request_status_codes` (status codes should be reported to Sentry)
+and `service_integration` (additional Sentry integrations) parameters.
 
 The Sentry configuration parameters are as follows:
 

--- a/docs_src/example_3.py
+++ b/docs_src/example_3.py
@@ -51,7 +51,11 @@ def error() -> str:
 
 def main() -> None:
     setup_logger(settings.log)
-    setup_sentry(settings.sentry, release='example_api@1.0')
+    setup_sentry(
+        settings.sentry,
+        release='example_api@1.0',
+        failed_request_status_codes=[range(400, 405), 422, range(500, 599)],
+    )
 
     uvicorn.run(
         app,


### PR DESCRIPTION
Added the ability to customize failed status codes during Sentry setup.